### PR TITLE
Resize images in memory instead of temp dir on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 binary/
+build/
+bin/
 
 .vs/
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@
 makeicon [-help] [-version] [-resize] [-platform:name] -sizes:x,y,z... -input:x,y,z... output
 ```
 
-A command-line utility for easily generating application icons from image files for
-a variety of different platforms. Icon generation is available for the following
-platforms: **Windows**, **iOS**, **MacOS**, **Android**.
+A command-line utility for generating application icons for **Windows**, **iOS**, **MacOS** and **Android**.
+
+### Example Usage
+
+```
+# Generating an .ico file on windows
+makeicon.exe -input:./assets/source/icon.png -sizes:256,128,64,32 -resize ./assets/built/icon.ico
+```
 
 ## Building
 

--- a/makeicon.cpp
+++ b/makeicon.cpp
@@ -267,7 +267,7 @@ static Argument format_argument(std::string arg_str)
     if(!tokens.empty())
     {
         arg.name = tokens[0];
-        if(tokens.size() > 1) // If we have parameters!
+        if(tokens.size() > 1) // We have parameters!
         {
             tokenize_string(tokens[1], ",", arg.params);
         }

--- a/makeicon.cpp
+++ b/makeicon.cpp
@@ -104,7 +104,7 @@ struct Image
 {
     s32 width  = 0;
     s32 height = 0;
-    s32 bpp    = 0;
+    s32 bpp    = 0; // bytes per pixel
     u8* data   = NULL;
 
     inline bool operator<(const Image& rhs) const
@@ -491,7 +491,7 @@ struct IconDirEntry
     u8  num_colors;
     u8  reserved;
     u16 color_planes;
-    u16 bpp;
+    u16 bpp; // bits per pixel
     u32 size;
     u32 offset;
 };

--- a/makeicon.cpp
+++ b/makeicon.cpp
@@ -665,21 +665,21 @@ s32 make_icon_apple(const Options& options, std::vector<Image>& input_images)
     f32 size = 0;
     while(getline(ss, to, '\n'))
     {
-        s32 start = to.find(": \"") + 3;
+        s32 start = CAST(s32, to.find(": \"") + 3);
 
         if(to.find("filename") != -1)
         {
-            s32 end = to.find("\",");
+            s32 end = CAST(s32, to.find("\","));
             filename = to.substr(start, (end - start));
         }
         else if(to.find("scale") != -1)
         {
-            s32 end = to.find("x");
+            s32 end = CAST(s32, to.find("x"));
             scale = std::stof(to.substr(start, (end - start)));
         }
         else if(to.find("size") != -1)
         {
-            s32 end = to.find("x");
+            s32 end = CAST(s32, to.find("x"));
             size = std::stof(to.substr(start, (end - start)));
         }
 
@@ -694,7 +694,7 @@ s32 make_icon_apple(const Options& options, std::vector<Image>& input_images)
         // Once all parameters are filled write out an image and reset.
         if(!filename.empty() && scale && size)
         {
-            resize_and_save_image(options.output + "/" + filename, input_images, size * scale, options.resize);
+            resize_and_save_image(options.output + "/" + filename, input_images, CAST(s32, size * scale), options.resize);
 
             filename = "";
             scale = 0;

--- a/makeicon.cpp
+++ b/makeicon.cpp
@@ -113,7 +113,7 @@ struct Image
     }
 };
 
-static bool save_image(Image& image, std::string file_name, s32 resize_width = 0, s32 resize_height = 0)
+static bool save_image(const Image& image, std::string file_name, s32 resize_width = 0, s32 resize_height = 0)
 {
     s32 output_width = (resize_width > 0) ? resize_width : image.width;
     s32 output_height = (resize_height > 0) ? resize_height : image.height;
@@ -146,7 +146,7 @@ static bool save_image(Image& image, std::string file_name, s32 resize_width = 0
     return true;
 }
 
-static void resize_and_save_image(const std::string& filename, std::vector<Image>& input_images, s32 size, bool resize)
+static void resize_and_save_image(const std::string& filename, const std::vector<Image>& input_images, s32 size, bool resize)
 {
     // Search for matching image input size to save out as PNG.
     bool match_found = false;
@@ -237,9 +237,9 @@ static Argument format_argument(std::string arg_str)
     return arg;
 }
 
-static s32 make_icon_win32(const Options& options, std::vector<Image>& input_images);
-static s32 make_icon_android(const Options& options, std::vector<Image>& input_images);
-static s32 make_icon_apple(const Options& options, std::vector<Image>& input_images);
+static s32 make_icon_win32(const Options& options, const std::vector<Image>& input_images);
+static s32 make_icon_android(const Options& options, const std::vector<Image>& input_images);
+static s32 make_icon_apple(const Options& options, const std::vector<Image>&input_images);
 
 static s32 make_icon(const Options& options)
 {
@@ -497,7 +497,7 @@ struct IconDirEntry
 };
 #pragma pack(pop)
 
-s32 make_icon_win32(const Options& options, std::vector<Image>& input_images)
+s32 make_icon_win32(const Options& options, const std::vector<Image>& input_images)
 {
     // Make sure the temporary directory, where we store all the icon PNGs, actually exists.
     std::filesystem::path temp_directory = "makeicon_temp/";
@@ -580,7 +580,7 @@ s32 make_icon_win32(const Options& options, std::vector<Image>& input_images)
 // Android
 //
 
-s32 make_icon_android(const Options& options, std::vector<Image>& input_images)
+s32 make_icon_android(const Options& options, const std::vector<Image>& input_images)
 {
     // Android needs specific downsampled sizes for thumbnails.
 
@@ -624,7 +624,7 @@ s32 make_icon_android(const Options& options, std::vector<Image>& input_images)
 // Apple
 //
 
-s32 make_icon_apple(const Options& options, std::vector<Image>& input_images)
+s32 make_icon_apple(const Options& options, const std::vector<Image>& input_images)
 {
     if(options.contents.empty())
     {

--- a/makeicon.cpp
+++ b/makeicon.cpp
@@ -76,9 +76,9 @@ static constexpr const char* PLATFORM_NAMES[Platform_COUNT] = { "win32", "osx", 
 static constexpr const char* MAKEICON_HELP_MESSAGE =
 "makeicon [-help] [-version] [-resize] [-platform:name] -sizes:x,y,z... -input:x,y,z... output\n"
 "\n"
-"    -sizes: ...  [Required]  Comma-separated input size(s) of icon image to generate for the output icon.\n"
-"    -input: ...  [Required]  Comma-separated input image(s) and/or directories and/or .txt files containing file names to be used to generate the icon sizes.\n"
-"    -resize      [Optional]  Whether to resize input images to match the specified sizes.\n"
+"    -sizes:...   [Required]  Comma-separated list of icon size(s) to be included in the generated output icon or a .json file to read sizes from on mac.\n"
+"    -input:...   [Required]  Comma-separated input image(s) and/or directories and/or .txt files containing file names to be used to generate the icon sizes.\n"
+"    -resize      [Optional]  Whether to allow resizing input images to match the requested output sizes, defaults to false.\n"
 "    -platform    [Optional]  Platform to generate icons for. Options are win32, osx, ios, android. Defaults to win32.\n"
 "    -version     [Optional]  Prints out the current version number of the makeicon binary and exits.\n"
 "    -help        [Optional]  Prints out this help/usage message for the program and exits.\n"
@@ -164,7 +164,7 @@ static void resize_and_save_image(const std::string& filename, std::vector<Image
         if(!resize)
         {
             // If no match was found and resize wasn't specified then we fail.
-            ERROR("Size %d was specified but no input image of this size was provided! Potentially specify -resize to allow for reszing to this size.", size);
+            ERROR("Size %d was requested but no input image of this size was provided! Potentially specify -resize to allow for reszing to this size.", size);
         }
         else
         {


### PR DESCRIPTION
Nice tool 😄 

The PR writes temp images to memory instead of disk, also tweaks some comments and README to clarify a few things from the perspective of a new user.

Feel free to reject, just thought I'd post since I made the changes already!

Maybe give it an extra test too, worked on my machine but.. ya know..

All the best ✌️ 